### PR TITLE
Self collisions and check

### DIFF
--- a/nist_gear/robots/gantry/gantry_description/urdf/gantry.urdf.xacro.template
+++ b/nist_gear/robots/gantry/gantry_description/urdf/gantry.urdf.xacro.template
@@ -181,6 +181,7 @@
       <gazebo reference="torso_base">
         <!--<material>Gazebo/RustySteel</material>-->
         <turnGravityOff>true</turnGravityOff>
+        <selfCollide>1</selfCollide>
       </gazebo>
 
       <joint name="torso_rail_joint" type="prismatic">
@@ -219,6 +220,7 @@
       <gazebo reference="torso_main">
         <!--<material>Gazebo/Black</material>-->
         <turnGravityOff>true</turnGravityOff>
+        <selfCollide>1</selfCollide>
       </gazebo>
 
 

--- a/nist_gear/robots/ur10/ur_description/urdf/ur10.urdf.macro.xacro
+++ b/nist_gear/robots/ur10/ur_description/urdf/ur10.urdf.macro.xacro
@@ -82,6 +82,9 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}base_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
 
     <!-- Joints -->
     <joint name="${prefix}arm_base_joint" type="fixed">
@@ -127,6 +130,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}shoulder_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
@@ -166,6 +173,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}upper_arm_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
@@ -202,6 +213,10 @@
         <origin xyz="0.0 0.0 ${-ur10_a3/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
+
+    <gazebo reference="${prefix}forearm_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
 
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
@@ -240,6 +255,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}wrist1_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
@@ -277,6 +296,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}wrist2_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
@@ -313,6 +336,10 @@
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
+
+    <gazebo reference="${prefix}wrist3_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
 
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />

--- a/nist_gear/robots/ur10/ur_description/urdf/ur10.urdf.xacro
+++ b/nist_gear/robots/ur10/ur_description/urdf/ur10.urdf.xacro
@@ -84,6 +84,9 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}base_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
 
     <!-- Joints -->
     <joint name="${prefix}arm_base_joint" type="fixed">
@@ -129,6 +132,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}shoulder_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}shoulder_lift_joint" type="revolute">
       <parent link="${prefix}shoulder_link" />
       <child link = "${prefix}upper_arm_link" />
@@ -168,6 +175,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}upper_arm_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}elbow_joint" type="revolute">
       <parent link="${prefix}upper_arm_link" />
       <child link = "${prefix}forearm_link" />
@@ -204,6 +215,10 @@
         <origin xyz="0.0 0.0 ${-ur10_a3/2.0}" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
+
+    <gazebo reference="${prefix}forearm_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
 
     <joint name="${prefix}wrist_1_joint" type="revolute">
       <parent link="${prefix}forearm_link" />
@@ -242,6 +257,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}wrist1_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}wrist_2_joint" type="revolute">
       <parent link="${prefix}wrist_1_link" />
       <child link = "${prefix}wrist_2_link" />
@@ -279,6 +298,10 @@
       </xacro:cylinder_inertial>
     </link>
 
+    <gazebo reference="${prefix}wrist2_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
+
     <joint name="${prefix}wrist_3_joint" type="revolute">
       <parent link="${prefix}wrist_2_link" />
       <child link = "${prefix}wrist_3_link" />
@@ -315,6 +338,10 @@
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0" />
       </xacro:cylinder_inertial>
     </link>
+
+    <gazebo reference="${prefix}wrist3_link">
+      <selfCollide>1</selfCollide>
+    </gazebo>
 
     <joint name="${prefix}ee_fixed_joint" type="fixed">
       <parent link="${prefix}wrist_3_link" />

--- a/nist_gear/src/ROSAriacTaskManagerPlugin.cc
+++ b/nist_gear/src/ROSAriacTaskManagerPlugin.cc
@@ -1213,6 +1213,7 @@ void ROSAriacTaskManagerPlugin::OnContactsReceived(ConstContactsPtr& _msg)
   for (int i = 0; i < _msg->contact_size(); ++i)
   {
     const auto & contact = _msg->contact(i);
+    /*
     bool col_1_is_arm = false;
     bool col_2_is_arm = false;
     for (const auto & collision_name : this->dataPtr->collisionFilter)
@@ -1227,6 +1228,18 @@ void ROSAriacTaskManagerPlugin::OnContactsReceived(ConstContactsPtr& _msg)
       }
     }
     if (col_1_is_arm && col_2_is_arm)
+    {
+      ROS_ERROR_STREAM("arm/arm contact detected: " << contact.collision1() << " and " << contact.collision2());
+      std::lock_guard<std::mutex> lock(this->dataPtr->mutex);
+      common::Time time(contact.time().sec(), contact.time().nsec());
+      this->dataPtr->ariacScorer.NotifyArmArmCollision(time);
+    }
+    */
+
+    // Simplified arm-arm and arm-torso collision, as all arm and torso links are prefaced with 'gantry::'
+    // e.g. gantry::left_forearm_link::left_forearm_link_collision and gantry::torso_main::torso_main_collision
+    if (contact.collision1().rfind("gantry", 0) == 0 and
+        contact.collision2().rfind("gantry", 0) == 0)
     {
       ROS_ERROR_STREAM("arm/arm contact detected: " << contact.collision1() << " and " << contact.collision2());
       std::lock_guard<std::mutex> lock(this->dataPtr->mutex);

--- a/nist_gear/src/ROSAriacTaskManagerPlugin.cc
+++ b/nist_gear/src/ROSAriacTaskManagerPlugin.cc
@@ -263,6 +263,13 @@ void ROSAriacTaskManagerPlugin::Load(physics::WorldPtr _world,
       "robot_namespace")->Get<std::string>() + "/";
   }
 
+  // Avoid the slowdown that is present with contact manager filter in gazebo 9.12 by subscribing to gazebo's main contact topic
+  // Note: Moved this out of the order parsing loop as it didn't need to be in there
+  //auto contact_manager = this->dataPtr->world->Physics()->GetContactManager();
+  //std::string contactTopic = contact_manager->CreateFilter("AriacTaskManagerFilter", this->dataPtr->collisionFilter);
+  //this->dataPtr->contactSub = this->dataPtr->node->Subscribe(contactTopic, &ROSAriacTaskManagerPlugin::OnContactsReceived, this);
+  this->dataPtr->contactSub = this->dataPtr->node->Subscribe("~/physics/contacts", &ROSAriacTaskManagerPlugin::OnContactsReceived, this);
+
   // Initialize ROS
   this->dataPtr->rosnode.reset(new ros::NodeHandle(robotNamespace));
 
@@ -468,10 +475,6 @@ void ROSAriacTaskManagerPlugin::Load(physics::WorldPtr _world,
 
       shipmentElem = shipmentElem->GetNextElement("shipment");
     }
-
-    auto contact_manager = this->dataPtr->world->Physics()->GetContactManager();
-    std::string contactTopic = contact_manager->CreateFilter("AriacTaskManagerFilter", this->dataPtr->collisionFilter);
-    this->dataPtr->contactSub = this->dataPtr->node->Subscribe(contactTopic, &ROSAriacTaskManagerPlugin::OnContactsReceived, this);
 
     // Add a new order.
     ariac::Order order = {orderID, startTime, interruptOnUnwantedProducts, interruptOnWantedProducts, allowedTime, shipments, 0.0};

--- a/nist_gear/src/ROSAriacTaskManagerPlugin.cc
+++ b/nist_gear/src/ROSAriacTaskManagerPlugin.cc
@@ -1238,7 +1238,9 @@ void ROSAriacTaskManagerPlugin::OnContactsReceived(ConstContactsPtr& _msg)
 
     // Simplified arm-arm and arm-torso collision, as all arm and torso links are prefaced with 'gantry::'
     // e.g. gantry::left_forearm_link::left_forearm_link_collision and gantry::torso_main::torso_main_collision
-    if (contact.collision1().rfind("gantry", 0) == 0 and
+    // Also - only check if competition has started, as arm is in collision when first spawned
+    if (this->dataPtr->currentState == "go" &&
+        contact.collision1().rfind("gantry", 0) == 0 &&
         contact.collision2().rfind("gantry", 0) == 0)
     {
       ROS_ERROR_STREAM("arm/arm contact detected: " << contact.collision1() << " and " << contact.collision2());


### PR DESCRIPTION
Modified xacro to enable self collisions on arm links and torso links.

Simplified and sped up collision self-collision determination in `ROSAriacTaskManagerPlugin::OnContactsReceived()`
The check now functions as intended.

Edit: The check now only happens in the plugin if the competition has started, because the arm spawns in self collision initially, then moves out of collision when the controller kicks in.