### PR TITLE
Force C++11 for avoiding iterator error

### DIFF
--- a/ariac_example/CMakeLists.txt
+++ b/ariac_example/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(ariac_example)
-
+add_compile_options(-std=c++11)
 find_package(catkin REQUIRED COMPONENTS
   nist_gear
   roscpp


### PR DESCRIPTION
Refer to issue #33 
This is a quick fix. Additionally should be implemented into all c++ files.