### PR TITLE
Qual 2 drop location fix

### DIFF
--- a/nist_gear/config/qual_a_2.yaml
+++ b/nist_gear/config/qual_a_2.yaml
@@ -114,13 +114,13 @@ faulty_products:
 drops:
   drop_regions:
     shipping_box_0_impeding:
-      frame: agv1::kit_tray_1
+      frame: agv2::kit_tray_2
       min:
         xyz: [-0.3, -0.3, 0.0]
       max:
         xyz: [0.3, 0.3, 0.5]
       destination:
-        xyz: [0.3, 0.3, 0.05]
+        xyz: [0.2, 0.3, 0.05]
         rpy: [0, 0, 0.2]
       product_type_to_drop: gasket_part_red
     shipping_box_1_impeding:
@@ -130,7 +130,7 @@ drops:
       max:
         xyz: [0.3, 0.3, 0.5]
       destination:
-        xyz: [0.3, 0.3, 0.05]
+        xyz: [0.2, 0.3, 0.05]
         rpy: [0, 0, 0.2]
       product_type_to_drop: gear_part_blue
 


### PR DESCRIPTION
* Both parts now drop over correct AGV (agv2)
* Drop location is now over tray instead of over to the side too far (tray is only 0.5m wide, so 0.3m offset meant that parts dropped onto ground and could not be recovered)