### PR TITLE
Change moveit_servo to moveit_ros as dependency or remove it

### DIFF
--- a/ariac_moveit_config/package.xml
+++ b/ariac_moveit_config/package.xml
@@ -21,7 +21,7 @@
   <exec_depend>moveit_planners_ompl</exec_depend>
   <exec_depend>moveit_ros_move_group</exec_depend>
   <exec_depend>moveit_ros_visualization</exec_depend>
-  <exec_depend>moveit_servo</exec_depend>
+  <exec_depend>moveit_ros</exec_depend>
   <exec_depend>moveit_simple_controller_manager</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>ur_description</exec_depend>


### PR DESCRIPTION
# Problem
When installing the dependency packages of ARIAC repo, I couldn't successfully run `rosdep install` command, since `moveit_servo` is not found, even after installing all the binaries of `moveit` (`sudo apt install ros-galactic-moveit`).