### PR TITLE
1) Feature to enable RViz, 2) pass .rviz file from downstream pkg, 3) Fix a missing dep

### DIFF
--- a/ariac_moveit_config/launch/ariac_robots_moveit.launch.py
+++ b/ariac_moveit_config/launch/ariac_robots_moveit.launch.py
@@ -35,8 +35,9 @@ def load_yaml(package_name, file_path):
     except EnvironmentError:  # parent of IOError, OSError *and* WindowsError where available
         return None
 
-
 def launch_setup(context, *args, **kwargs):
+    rviz_config_file = LaunchConfiguration("rviz_conf")
+        
     # Generate Robot Description parameter from xacro
     robot_description_content = Command(
         [
@@ -99,12 +100,7 @@ def launch_setup(context, *args, **kwargs):
             {"use_sim_time": True},
         ],
     )
-
-    # rviz with moveit configuration
-    rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("ariac_moveit_config"), "rviz", "moveit.rviz"]
-    )
-
+  
     rviz_node = Node(
         package="rviz2",
         executable="rviz2",
@@ -121,13 +117,19 @@ def launch_setup(context, *args, **kwargs):
     
     nodes_to_start = [
         move_group_node,
-        # rviz_node    
+        rviz_node
     ]
 
     return nodes_to_start
 
 
 def generate_launch_description():
-    declared_arguments = []
+    # rviz with moveit configuration
+    _launcharg_rviz_config = DeclareLaunchArgument(
+        'rviz_conf',
+        default_value= PathJoinSubstitution(
+            [FindPackageShare("ariac_moveit_config"), "rviz", "moveit.rviz"]))
+    
+    declared_arguments = [_launcharg_rviz_config]
 
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/ariac_moveit_config/package.xml
+++ b/ariac_moveit_config/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_python</buildtool_depend>
 
+  <depend>ariac_description</depend>
   <depend>backward_ros</depend>
 
   <exec_depend>launch</exec_depend>


### PR DESCRIPTION
# Issue
- `ariac_description` is not depended by any package on ARIAC repo. While it hasn't mattered, it's better to make it right.
- In `ariac_moveit_config/launch/ariac_robots_moveit.launch.py`, path to RViz' config file, which does a lot of stuff (mostly MoveIt-specific configurations) in it, is hardcoded so downstream <s>cannot easily open their own</s> switch to their own config.

# Condition of Satisfaction (CoS)
- In downstream (that includes the .launch.py file in question) can set their own .rviz file.
- By default RViz is disabled.

# Review status
- [x] Verified the CoS by the author.
