### PR TITLE
Static Controllers 

### DIFF
--- a/ariac_controllers/CMakeLists.txt
+++ b/ariac_controllers/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(controller_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
 find_package(hardware_interface REQUIRED)
-find_package(Eigen3 REQUIRED)
 
 add_library(
   ${PROJECT_NAME}
@@ -25,11 +24,10 @@ add_library(
   src/static_controller.cpp
 )
 
-  target_include_directories(
+target_include_directories(
   ${PROJECT_NAME}
   PUBLIC
   include
-  ${EIGEN3_INCLUDE_DIRS}
 )
 
 ament_target_dependencies(
@@ -60,9 +58,11 @@ install(
 ament_export_include_directories(
   include
 )
+
 ament_export_libraries(
   ${PROJECT_NAME}
 )
+
 ament_export_dependencies(
   controller_interface
   pluginlib
@@ -70,4 +70,5 @@ ament_export_dependencies(
   rclcpp_lifecycle
   hardware_interface
 )
+
 ament_package()

--- a/ariac_controllers/CMakeLists.txt
+++ b/ariac_controllers/CMakeLists.txt
@@ -1,0 +1,73 @@
+cmake_minimum_required(VERSION 3.5)
+project(ariac_controllers)
+
+# Default to C++14
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(rclcpp_lifecycle REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(Eigen3 REQUIRED)
+
+add_library(
+  ${PROJECT_NAME}
+  SHARED
+  src/static_controller.cpp
+)
+
+  target_include_directories(
+  ${PROJECT_NAME}
+  PUBLIC
+  include
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+ament_target_dependencies(
+  ${PROJECT_NAME}
+  controller_interface
+  hardware_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+)
+
+pluginlib_export_plugin_description_file(
+  controller_interface controllers.xml)
+
+install(
+  TARGETS
+  ${PROJECT_NAME}
+  RUNTIME DESTINATION bin
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+ament_export_include_directories(
+  include
+)
+ament_export_libraries(
+  ${PROJECT_NAME}
+)
+ament_export_dependencies(
+  controller_interface
+  pluginlib
+  rclcpp
+  rclcpp_lifecycle
+  hardware_interface
+)
+ament_package()

--- a/ariac_controllers/controllers.xml
+++ b/ariac_controllers/controllers.xml
@@ -1,0 +1,8 @@
+<library path="ariac_controllers">
+    <class name="ariac_controllers/StaticController"
+           type="ariac_controllers::StaticController" base_class_type="controller_interface::ControllerInterface">
+        <description>
+            The static controller keeps the current state of the robot
+        </description>
+    </class>
+</library>

--- a/ariac_controllers/include/ariac_controllers/static_controller.hpp
+++ b/ariac_controllers/include/ariac_controllers/static_controller.hpp
@@ -30,7 +30,5 @@ class StaticController : public controller_interface::ControllerInterface {
  private:
   std::vector<std::string> joint_names_;
   std::vector<double> joint_states_;
-
-  void updateJointStates();
 };
 }  // namespace ariac_controllers

--- a/ariac_controllers/include/ariac_controllers/static_controller.hpp
+++ b/ariac_controllers/include/ariac_controllers/static_controller.hpp
@@ -1,9 +1,14 @@
+/*
+This software was developed by employees of the National Institute of Standards and Technology (NIST), an agency of the Federal Government. Pursuant to title 17 United States Code Section 105, works of NIST employees are not subject to copyright protection in the United States and are considered to be in the public domain. Permission to freely use, copy, modify, and distribute this software and its documentation without fee is hereby granted, provided that this notice and disclaimer of warranty appears in all copies.
+
+The software is provided 'as is' without any warranty of any kind, either expressed, implied, or statutory, including, but not limited to, any warranty that the software will conform to specifications, any implied warranties of merchantability, fitness for a particular purpose, and freedom from infringement, and any warranty that the documentation will conform to the software, or any warranty that the software will be error free. In no event shall NIST be liable for any damages, including, but not limited to, direct, indirect, special or consequential damages, arising out of, resulting from, or in any way connected with this software, whether or not based upon warranty, contract, tort, or otherwise, whether or not injury was sustained by persons or property or otherwise, and whether or not loss was sustained from, or arose out of the results of, or use of, the software or services provided hereunder.
+
+Distributions of NIST software should also include copyright and licensing statements of any third-party software that are legally bundled with the code in compliance with the conditions of those licenses.
+*/
+
 #pragma once
 
-#include <memory>
 #include <string>
-
-#include <Eigen/Eigen>
 #include <controller_interface/controller_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 

--- a/ariac_controllers/include/ariac_controllers/static_controller.hpp
+++ b/ariac_controllers/include/ariac_controllers/static_controller.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <Eigen/Eigen>
+#include <controller_interface/controller_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
+
+namespace ariac_controllers {
+
+/// The move to start example controller moves the robot into default pose.
+class StaticController : public controller_interface::ControllerInterface {
+ public:
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+  controller_interface::return_type update(const rclcpp::Time& time,
+                                           const rclcpp::Duration& period) override;
+  CallbackReturn on_init() override;
+  CallbackReturn on_configure(const rclcpp_lifecycle::State& previous_state) override;
+  CallbackReturn on_activate(const rclcpp_lifecycle::State& previous_state) override;
+
+ private:
+  std::vector<std::string> joint_names_;
+  std::vector<double> joint_states_;
+
+  void updateJointStates();
+};
+}  // namespace ariac_controllers

--- a/ariac_controllers/include/ariac_controllers/static_controller.hpp
+++ b/ariac_controllers/include/ariac_controllers/static_controller.hpp
@@ -16,7 +16,6 @@ using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface
 
 namespace ariac_controllers {
 
-/// The move to start example controller moves the robot into default pose.
 class StaticController : public controller_interface::ControllerInterface {
  public:
   controller_interface::InterfaceConfiguration command_interface_configuration() const override;

--- a/ariac_controllers/package.xml
+++ b/ariac_controllers/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ariac_controllers</name>
+  <version>0.0.0</version>
+  <description>ros2 controllers for ARIAC simulation</description>
+  <maintainer email="justin.albrecht@nist.gov"> Justin Albrecht</maintainer>
+  <license>NIST</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>controller_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp_lifecycle</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/ariac_controllers/src/static_controller.cpp
+++ b/ariac_controllers/src/static_controller.cpp
@@ -1,24 +1,15 @@
-// Copyright (c) 2021 Franka Emika GmbH
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+/*
+This software was developed by employees of the National Institute of Standards and Technology (NIST), an agency of the Federal Government. Pursuant to title 17 United States Code Section 105, works of NIST employees are not subject to copyright protection in the United States and are considered to be in the public domain. Permission to freely use, copy, modify, and distribute this software and its documentation without fee is hereby granted, provided that this notice and disclaimer of warranty appears in all copies.
+
+The software is provided 'as is' without any warranty of any kind, either expressed, implied, or statutory, including, but not limited to, any warranty that the software will conform to specifications, any implied warranties of merchantability, fitness for a particular purpose, and freedom from infringement, and any warranty that the documentation will conform to the software, or any warranty that the software will be error free. In no event shall NIST be liable for any damages, including, but not limited to, direct, indirect, special or consequential damages, arising out of, resulting from, or in any way connected with this software, whether or not based upon warranty, contract, tort, or otherwise, whether or not injury was sustained by persons or property or otherwise, and whether or not loss was sustained from, or arose out of the results of, or use of, the software or services provided hereunder.
+
+Distributions of NIST software should also include copyright and licensing statements of any third-party software that are legally bundled with the code in compliance with the conditions of those licenses.
+*/
 
 #include <ariac_controllers/static_controller.hpp>
 
-#include <cassert>
-#include <cmath>
 #include <exception>
 
-#include <Eigen/Eigen>
 #include <controller_interface/controller_interface.hpp>
 
 namespace ariac_controllers {

--- a/ariac_controllers/src/static_controller.cpp
+++ b/ariac_controllers/src/static_controller.cpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2021 Franka Emika GmbH
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <ariac_controllers/static_controller.hpp>
+
+#include <cassert>
+#include <cmath>
+#include <exception>
+
+#include <Eigen/Eigen>
+#include <controller_interface/controller_interface.hpp>
+
+namespace ariac_controllers {
+
+controller_interface::InterfaceConfiguration
+StaticController::command_interface_configuration() const {
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+
+  for (std::string name : joint_names_) {
+    config.names.push_back(name + "/position");
+  }
+
+  return config;
+}
+
+controller_interface::InterfaceConfiguration
+StaticController::state_interface_configuration() const {
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+
+  for (std::string name : joint_names_) {
+    config.names.push_back(name + "/position");
+  }
+
+  return config;
+}
+
+controller_interface::return_type StaticController::update(
+  const rclcpp::Time& /*time*/,
+  const rclcpp::Duration& /*period*/) 
+{
+
+  for (int i = 0; i < int(command_interfaces_.size()); ++i) {
+    command_interfaces_[i].set_value(joint_states_[i]);
+  }
+
+  return controller_interface::return_type::OK;
+}
+
+CallbackReturn StaticController::on_init() {
+  try
+  {
+    auto_declare<std::vector<std::string>>("joints", {});
+  }
+  catch (const std::exception & e)
+  {
+    fprintf(stderr, "Exception thrown during init stage with message: %s \n", e.what());
+    return CallbackReturn::ERROR;
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn StaticController::on_configure(
+  const rclcpp_lifecycle::State&) 
+{
+  joint_names_ = get_node()->get_parameter("joints").as_string_array();
+
+  if (joint_names_.empty()) {
+    RCLCPP_FATAL(get_node()->get_logger(), "joints parameter not set");
+    return CallbackReturn::FAILURE;
+  }
+
+  return CallbackReturn::SUCCESS;
+}
+
+CallbackReturn StaticController::on_activate(
+    const rclcpp_lifecycle::State&)
+{
+  joint_states_.clear();
+
+  for (int i = 0; i < int(state_interfaces_.size()); ++i) {
+    const auto& position_interface = state_interfaces_.at(i);
+
+    joint_states_.push_back(position_interface.get_value());
+  }
+  
+  return CallbackReturn::SUCCESS;
+}
+
+}  // namespace ariac_controllers
+#include "pluginlib/class_list_macros.hpp"
+// NOLINTNEXTLINE
+PLUGINLIB_EXPORT_CLASS(ariac_controllers::StaticController,
+                       controller_interface::ControllerInterface)

--- a/ariac_description/config/robot_controllers.yaml
+++ b/ariac_description/config/robot_controllers.yaml
@@ -30,6 +30,12 @@ controller_manager:
     agv4_controller:
       type: velocity_controllers/JointGroupVelocityController
 
+    floor_robot_static_controller:
+      type: ariac_controllers/StaticController
+    
+    ceiling_robot_static_controller:
+      type: ariac_controllers/StaticController
+
 
 floor_robot_controller:
   ros__parameters:
@@ -174,3 +180,28 @@ agv4_controller:
     state_interfaces:
       - position
 
+
+floor_robot_static_controller:
+  ros__parameters:
+    joints:
+      - linear_actuator_joint
+      - floor_shoulder_pan_joint
+      - floor_shoulder_lift_joint
+      - floor_elbow_joint
+      - floor_wrist_1_joint
+      - floor_wrist_2_joint
+      - floor_wrist_3_joint
+
+
+ceiling_robot_static_controller:
+  ros__parameters:
+    joints:
+      - gantry_x_axis_joint
+      - gantry_y_axis_joint
+      - gantry_rotation_joint
+      - ceiling_shoulder_pan_joint
+      - ceiling_shoulder_lift_joint
+      - ceiling_elbow_joint
+      - ceiling_wrist_1_joint
+      - ceiling_wrist_2_joint
+      - ceiling_wrist_3_joint

--- a/ariac_gazebo/config/trials/kitting.yaml
+++ b/ariac_gazebo/config/trials/kitting.yaml
@@ -37,4 +37,3 @@ orders:
         - type: 'pump'
           color: 'purple'
           quadrant: 1
-

--- a/ariac_gazebo/config/trials/kitting.yaml
+++ b/ariac_gazebo/config/trials/kitting.yaml
@@ -37,9 +37,3 @@ orders:
         - type: 'pump'
           color: 'purple'
           quadrant: 1
-
-challenges:
-- robot_malfunction:
-    duration: 10.0
-    robots_to_disable: ['floor_robot']
-    time_condition: 5.0

--- a/ariac_gazebo/config/trials/kitting.yaml
+++ b/ariac_gazebo/config/trials/kitting.yaml
@@ -37,3 +37,4 @@ orders:
         - type: 'pump'
           color: 'purple'
           quadrant: 1
+

--- a/ariac_gazebo/config/trials/kitting.yaml
+++ b/ariac_gazebo/config/trials/kitting.yaml
@@ -37,3 +37,9 @@ orders:
         - type: 'pump'
           color: 'purple'
           quadrant: 1
+
+challenges:
+- robot_malfunction:
+    duration: 10.0
+    robots_to_disable: ['floor_robot']
+    time_condition: 5.0

--- a/ariac_gazebo/launch/ariac.launch.py
+++ b/ariac_gazebo/launch/ariac.launch.py
@@ -131,11 +131,13 @@ def launch_setup(context, *args, **kwargs):
         'agv2_controller',
         'agv3_controller',
         'agv4_controller',
+        'floor_robot_static_controller',
+        'ceiling_robot_static_controller',
     ]
 
     controller_spawner_nodes = []
     for controller in controller_names:
-        if controller == 'joint_state_broadcaster' or controller.count('agv') > 0:
+        if controller == 'joint_state_broadcaster' or controller.count('agv') > 0 or controller.count('static') > 0:
             args = [controller]
         else:
             args = [controller, '--inactive']

--- a/ariac_gazebo/nodes/environment_startup_node.py
+++ b/ariac_gazebo/nodes/environment_startup_node.py
@@ -14,8 +14,6 @@ def main():
     # Wait five seconds for gazebo to start up
     time.sleep(2)
 
-    # startup_node.pause_physics()
-
     # Spawn robots
     startup_node.spawn_robots()
 
@@ -37,13 +35,11 @@ def main():
     # Parse the trial config file
     startup_node.parse_trial_file()
 
-    # startup_node.unpause_physics()
-
     try:
         rclpy.spin(startup_node)
-    except:
+    except KeyboardInterrupt:
         startup_node.destroy_node()
-        rclpy.shutdown()
+
 
 if __name__ == '__main__':
     main()

--- a/ariac_gazebo/nodes/object_tf_broadcaster.py
+++ b/ariac_gazebo/nodes/object_tf_broadcaster.py
@@ -118,9 +118,7 @@ def main():
     try:
         rclpy.spin(objects_tf_broadcaster)
     except KeyboardInterrupt:
-        pass
-
-    rclpy.shutdown()
+        objects_tf_broadcaster.destroy_node()
 
 if __name__ == '__main__':
     main()

--- a/ariac_gazebo/nodes/part_spawner.py
+++ b/ariac_gazebo/nodes/part_spawner.py
@@ -47,5 +47,4 @@ if __name__ == "__main__":
     part_spawner.spawn_part("green_pump_99", "pump", "green", [-7.5, -3, 1.5], [0, 0, 0])
 
     part_spawner.destroy_node()
-    rclpy.shutdown()
 

--- a/ariac_gazebo/nodes/robot_controller_switcher_node.py
+++ b/ariac_gazebo/nodes/robot_controller_switcher_node.py
@@ -89,6 +89,6 @@ if __name__ == "__main__":
 
     robot_controller_switcher.run()
 
-    rclpy.shutdown()
+    robot_controller_switcher.destroy_node()
 
     

--- a/ariac_gazebo/nodes/robot_controller_switcher_node.py
+++ b/ariac_gazebo/nodes/robot_controller_switcher_node.py
@@ -44,21 +44,25 @@ class RobotControllerSwitcher(Node):
                     for controller in self.floor_robot_controllers:
                         self.request.activate_controllers.append(controller)
                         self.floor_robot_state = True
+                    self.request.deactivate_controllers.append("floor_robot_static_controller")
                 
                 if self.ceiling_robot_health and not self.ceiling_robot_state:
                     for controller in self.ceiling_robot_controllers:
                         self.request.activate_controllers.append(controller)
                         self.ceiling_robot_state = True
+                    self.request.deactivate_controllers.append("ceiling_robot_static_controller")
                 
                 if not self.floor_robot_health and self.floor_robot_state:
                     for controller in self.floor_robot_controllers:
                         self.request.deactivate_controllers.append(controller)
                         self.floor_robot_state = False
+                    self.request.activate_controllers.append("floor_robot_static_controller")
 
                 if not self.ceiling_robot_health and self.ceiling_robot_state:
                     for controller in self.ceiling_robot_controllers:
                         self.request.deactivate_controllers.append(controller)
                         self.ceiling_robot_state = False
+                    self.request.activate_controllers.append("ceiling_robot_static_controller")
 
                 if self.request.activate_controllers or self.request.deactivate_controllers:
                     future = self.controller_switcher.call_async(self.request)

--- a/ariac_gazebo/nodes/sensor_tf_broadcaster.py
+++ b/ariac_gazebo/nodes/sensor_tf_broadcaster.py
@@ -46,9 +46,7 @@ def main():
     try:
         rclpy.spin(sensor_tf_broadcaster)
     except KeyboardInterrupt:
-        pass
-
-    rclpy.shutdown()
+        sensor_tf_broadcaster.destroy_node()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### Purpose
Fixes issue present in ROS iron where robots without an active controller would slowly drift due to gravity. 

### Changes:
- Added new package ariac_controllers 
- created new static controller that reads the state of the robot at the time of activation and continuously sets the state of the command interface to the start state
- added static controllers to the yaml file for both floor and ceiling robot
- modified ariac launch file to properly load the new static controllers
- modified robot_controller_switcher node to properly activate/deactivate the static controllers based on the robot_health topic