### PR TITLE
Remove tray and parts from AGV after submitting a kitting order

### DIFF
--- a/ariac_plugins/src/agv_tray_plugin.cpp
+++ b/ariac_plugins/src/agv_tray_plugin.cpp
@@ -47,6 +47,7 @@ public:
   gazebo::transport::SubscriberPtr contact_sub_;
   gazebo::transport::NodePtr gznode_;
 
+  // Position of warehouse for agv_joint 
   double warehouse_location_ = 17;
 
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr lock_tray_service_;

--- a/ariac_plugins/src/agv_tray_plugin.cpp
+++ b/ariac_plugins/src/agv_tray_plugin.cpp
@@ -47,13 +47,14 @@ public:
   gazebo::transport::SubscriberPtr contact_sub_;
   gazebo::transport::NodePtr gznode_;
 
-
+  double warehouse_location_ = 17;
 
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr lock_tray_service_;
   rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr unlock_tray_service_;
 
   gazebo::physics::ModelPtr model_;
   gazebo::physics::JointPtr kit_tray_joint_;
+  gazebo::physics::JointPtr agv_joint_;
   gazebo::physics::JointPtr sensor_joint_;
   gazebo::physics::CollisionPtr model_collision_;
   std::map<std::string, gazebo::physics::CollisionPtr> collisions_;
@@ -111,6 +112,8 @@ void AGVTrayPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
   // Get gripper link
   std::string link_name = sdf->GetElement("agv_tray_link")->Get<std::string>();
   impl_->agv_tray_link_ = impl_->model_->GetLink(link_name);
+
+  impl_->agv_joint_ = model->GetJoint(impl_->agv_number_ + "_joint");
   
   std::string topic = "/gazebo/world/ariac_robots/" + link_name + "/bumper/contacts";
   impl_->contact_sub_ = impl_->gznode_->Subscribe(topic, &AGVTrayPlugin::OnContact, this);
@@ -164,6 +167,13 @@ void AGVTrayPlugin::OnUpdate()
     }
   }
 
+  // Unlock tray if agv is at the warehouse
+  if (abs(impl_->agv_joint_->Position(0) - impl_->warehouse_location_) < 0.05 && impl_->tray_attached_) {
+    // RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(), "AGV in warehouse, unlocking tray");
+    impl_->DetachJoint();
+    impl_->locked_ = false;
+
+  }
 }
 
 void AGVTrayPlugin::OnContact(ConstContactsPtr& _msg){

--- a/ariac_plugins/src/agv_tray_plugin.cpp
+++ b/ariac_plugins/src/agv_tray_plugin.cpp
@@ -168,7 +168,7 @@ void AGVTrayPlugin::OnUpdate()
   }
 
   // Unlock tray if agv is at the warehouse
-  if (abs(impl_->agv_joint_->Position(0) - impl_->warehouse_location_) < 0.05 && impl_->tray_attached_) {
+  if (abs(impl_->agv_joint_->Position(0) - impl_->warehouse_location_) < 0.3 && impl_->tray_attached_) {
     // RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(), "AGV in warehouse, unlocking tray");
     impl_->DetachJoint();
     impl_->locked_ = false;

--- a/ariac_plugins/src/task_manager_plugin.cpp
+++ b/ariac_plugins/src/task_manager_plugin.cpp
@@ -1943,8 +1943,12 @@ namespace ariac_plugins
             if (!model) {
                 RCLCPP_INFO_STREAM(ros_node_->get_logger(), "Unable to remove " << name.c_str());
             } else {
+                auto pose = model->WorldPose();
+                pose.SetZ(-1.0);
+                model->SetWorldPose(pose);
                 model->SetAutoDisable(true);
                 model->SetCollideMode("none");
+                // RCLCPP_INFO_STREAM(ros_node_->get_logger(), "Removing: " << name.c_str());
 
                 // gazebo::physics::Joint_V joints = model->GetJoints();
                 // for (unsigned int i=0; i< joints.size(); i++)

--- a/test_competitor/include/test_competitor/test_competitor.hpp
+++ b/test_competitor/include/test_competitor/test_competitor.hpp
@@ -69,6 +69,7 @@ public:
   bool StartCompetition();
   bool EndCompetition();
   bool LockAGVTray(int agv_num);
+  bool UnlockAGVTray(int agv_num);
   bool MoveAGV(int agv_num, int destination);
   bool SubmitOrder(std::string order_id);
 

--- a/test_competitor/src/test_competitor.cpp
+++ b/test_competitor/src/test_competitor.cpp
@@ -1286,8 +1286,6 @@ bool TestCompetitor::CompleteKittingTask(ariac_msgs::msg::KittingTask task)
 
   MoveAGV(task.agv_number, task.destination);
 
-  UnlockAGVTray(task.agv_number);
-
   return true;
 }
 

--- a/test_competitor/src/test_competitor.cpp
+++ b/test_competitor/src/test_competitor.cpp
@@ -1286,6 +1286,8 @@ bool TestCompetitor::CompleteKittingTask(ariac_msgs::msg::KittingTask task)
 
   MoveAGV(task.agv_number, task.destination);
 
+  UnlockAGVTray(task.agv_number);
+
   return true;
 }
 
@@ -1562,6 +1564,22 @@ bool TestCompetitor::LockAGVTray(int agv_num)
   rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client;
 
   std::string srv_name = "/ariac/agv" + std::to_string(agv_num) + "_lock_tray";
+
+  client = this->create_client<std_srvs::srv::Trigger>(srv_name);
+
+  auto request = std::make_shared<std_srvs::srv::Trigger::Request>();
+
+  auto future = client->async_send_request(request);
+  future.wait();
+
+  return future.get()->success;
+}
+
+bool TestCompetitor::UnlockAGVTray(int agv_num)
+{
+  rclcpp::Client<std_srvs::srv::Trigger>::SharedPtr client;
+
+  std::string srv_name = "/ariac/agv" + std::to_string(agv_num) + "_unlock_tray";
 
   client = this->create_client<std_srvs::srv::Trigger>(srv_name);
 


### PR DESCRIPTION
* Adds logic to agv_tray_plugin to unlock the tray when it arrives at the warehouse
* Task Manager removes the parts from the AGV after scoring the kitting task
* Add method to Test Competitor to unlock the AGV tray (Currently unused)
