### PR TITLE
Logging updates

### DIFF
--- a/ariac_gazebo/ariac_gazebo/environment_startup.py
+++ b/ariac_gazebo/ariac_gazebo/environment_startup.py
@@ -231,7 +231,7 @@ class EnvironmentStartup(Node):
                 self.get_logger().fatal("Unable to find ariac_logs directory")
                 return
 
-            self.trial_log_folder = parent_folder + message.trial_name.split('.')[0] + "_" + time.strftime("%Y_%m_%d_%I_%M_%S") + "/"
+            self.trial_log_folder = parent_folder + message.trial_name.split('.')[0] + "_" + time.strftime("%Y_%m_%d_%H_%M_%S") + "/"
 
             # ariac_msgs/msg/Trial.msg: log_folder_path
             message.log_folder_path = self.trial_log_folder
@@ -250,7 +250,7 @@ class EnvironmentStartup(Node):
             self.get_logger().fatal("Unable to create log folder")
 
         self.get_logger().info(bcolors.OKCYAN + "ARIAC logs for this trial can be found at:" + bcolors.ENDC)
-        self.get_logger().info(bcolors.OKCYAN + '  ' + self.trial_log_folder + bcolors.ENDC)
+        self.get_logger().info(bcolors.OKCYAN + self.trial_log_folder + bcolors.ENDC)
 
         # publish to topic /ariac/trial_config
         self.trial_info_pub.publish(message)

--- a/ariac_msgs/msg/Trial.msg
+++ b/ariac_msgs/msg/Trial.msg
@@ -1,5 +1,6 @@
 float32 time_limit
 string trial_name
+string log_folder_path
 ariac_msgs/Order[] orders
 ariac_msgs/OrderCondition[] order_conditions
 ariac_msgs/Challenge[] challenges

--- a/ariac_plugins/include/ariac_plugins/ariac_common.hpp
+++ b/ariac_plugins/include/ariac_plugins/ariac_common.hpp
@@ -327,8 +327,7 @@ namespace ariac_common
                                         const KittingPart &obj)
         {
             out << "   ------" << std::endl;
-            out << "   Part: " << obj.part_ << std::endl;
-            out << "   Quadrant: " << obj.quadrant_;
+            out << "   Part: " << obj.part_ << "\tQuadrant: " << obj.quadrant_;
             return out;
         }
 
@@ -536,18 +535,18 @@ namespace ariac_common
         friend std::ostream &operator<<(std::ostream &out,
                                         const KittingTask &obj)
         {
-            out << "   Kitting Task" << std::endl;
-            out << "   ================" << std::endl;
+            // out << "   Kitting Task" << std::endl;
+            // out << "   ================" << std::endl;
 
-            out << "   AGV: " << obj.agv_number_ << std::endl;
-            out << "   Tray ID: " << obj.tray_id_ << std::endl;
+            out << "AGV: " << obj.agv_number_ << std::endl;
+            out << "Tray ID: " << obj.tray_id_ << std::endl;
 
             // Destination
-            out << "   Destination: " << ConvertDestinationToString(obj.destination_, obj.agv_number_) << std::endl;
+            out << "Destination: " << ConvertDestinationToString(obj.destination_, obj.agv_number_) << std::endl;
 
             // Products
-            out << "   ================" << std::endl;
-            out << "   Products: " << std::endl;
+            // out << "   ================" << std::endl;
+            out << "Products: " << std::endl;
             for (const auto &product : obj.products_)
             {
                 out << product << std::endl;
@@ -1617,7 +1616,7 @@ namespace ariac_common
                                         const Order &obj)
         {
             out << "=================" << std::endl;
-            out << "Announcing Order " << obj.id_ << std::endl;
+            out << "Order ID: " << obj.id_ << std::endl;
             out << "=================" << std::endl;
             if (obj.type_ == ariac_msgs::msg::Order::KITTING)
                 out << "Type: Kitting" << std::endl;

--- a/ariac_plugins/include/ariac_plugins/ariac_common.hpp
+++ b/ariac_plugins/include/ariac_plugins/ariac_common.hpp
@@ -56,6 +56,39 @@ namespace ariac_common
     class KittingScore;
     class ScoredAssemblyPart;
 
+
+
+    //==============================================================================
+    /**
+     * @brief Helper function to display information in the terminal
+    */
+    std::string static TerminalDisplay(std::string message, std::string color){
+        std::string color_code = "";
+
+        if (color == "red")
+            color_code = "\033[1;31m";
+        else if (color == "green")
+            color_code = "\033[1;32m";
+        else if (color == "yellow")
+            color_code = "\033[1;33m";
+        else if (color == "blue")
+            color_code = "\033[1;34m";
+        else if (color == "magenta")
+            color_code = "\033[1;35m";
+        else if (color == "cyan")
+            color_code = "\033[1;36m";
+        else if (color == "white")
+            color_code = "\033[1;37m";
+        else
+            color_code = "\033[1;31m";
+        
+        auto output = color_code + message + "\033[0m";
+
+        // log_message_ += message;
+        
+        return output;
+    }
+
     //==============================================================================
     /**
      * @brief Helper function to convert a part type to a string
@@ -438,16 +471,16 @@ namespace ariac_common
         friend std::ostream &operator<<(std::ostream &out,
                                         const AssemblyTask &obj)
         {
-            out << "   Assembly Task" << std::endl;
-            out << "   ================" << std::endl;
+            // out << "   Assembly Task" << std::endl;
+            // out << "   ================" << std::endl;
 
             if (obj.agv_numbers_.size() == 1)
-                out << "   AGV: [" << obj.agv_numbers_[0] << "]" << std::endl;
+                out << "AGV: [" << obj.agv_numbers_[0] << "]" << std::endl;
             else
             {
                 int counter = obj.agv_numbers_.size();
 
-                out << "   AGV: [";
+                out << "AGV: [";
                 for (auto agv_number : obj.agv_numbers_)
                 {
                     counter--;
@@ -464,7 +497,7 @@ namespace ariac_common
 
             // Products
             out << "   ================" << std::endl;
-            out << "   Products: " << std::endl;
+            out << "   Products " << std::endl;
             for (const auto &product : obj.products_)
             {
                 out << product << std::endl;
@@ -545,8 +578,8 @@ namespace ariac_common
             out << "Destination: " << ConvertDestinationToString(obj.destination_, obj.agv_number_) << std::endl;
 
             // Products
-            // out << "   ================" << std::endl;
-            out << "Products: " << std::endl;
+            out << "    ================" << std::endl;
+            out << "    Products " << std::endl;
             for (const auto &product : obj.products_)
             {
                 out << product << std::endl;
@@ -651,7 +684,7 @@ namespace ariac_common
 
             // Products
             out << "   ================" << std::endl;
-            out << "   Products: " << std::endl;
+            out << "   Products " << std::endl;
             for (const auto &product : obj.products_)
             {
                 out << product << std::endl;

--- a/ariac_plugins/src/task_manager_plugin.cpp
+++ b/ariac_plugins/src/task_manager_plugin.cpp
@@ -507,8 +507,9 @@ namespace ariac_plugins
             std::bind(&TaskManagerPlugin::OnUpdate, this));
 
         // Init subscribers
+        auto qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();
         impl_->trial_config_sub_ = impl_->ros_node_->create_subscription<ariac_msgs::msg::Trial>(
-            "/ariac/trial_config", qos.get_subscription_qos("/ariac/trial_config", rclcpp::QoS(1)),
+            "/ariac/trial_config", qos.get_subscription_qos("/ariac/trial_config", qos_profile),
             std::bind(&TaskManagerPlugin::OnTrialCallback, this, std::placeholders::_1));
 
         impl_->agv1_status_ = impl_->ros_node_->create_subscription<ariac_msgs::msg::AGVStatus>(

--- a/ariac_plugins/src/task_manager_plugin.cpp
+++ b/ariac_plugins/src/task_manager_plugin.cpp
@@ -276,13 +276,13 @@ namespace ariac_plugins
         void Station4SensorCallback(ConstLogicalCameraImagePtr &_msg);
 
         //============== Score Displays =================
+        /*!< Print details of the score for a kitting task. */
+        void PrintKittingScore(std::shared_ptr<ariac_common::Order> _order, bool _log_output=false, bool _terminal_display=false);
         /*!< Print details of the score for an assembly task. */
         void PrintAssemblyScore(std::shared_ptr<ariac_common::Order> _order, bool _log_output=false, bool _terminal_display=false);
         /*!< Print details of the score for a combined task. */
         void PrintCombinedScore(std::shared_ptr<ariac_common::CombinedScore> combined_score);
-        /*!< Print details of the score for a kitting task. */
-        // void PrintKittingScore(std::shared_ptr<ariac_common::KittingScore> kitting_score, int expected_number_of_parts, std::string& output);
-        void TaskManagerPluginPrivate::PrintKittingScore(std::shared_ptr<ariac_common::Order> _order, bool _log_output, bool _terminal_display)
+        
 
         /*!< Print details of the score for the trial. */
         void PrintTrialScore(
@@ -2599,7 +2599,7 @@ namespace ariac_plugins
         // Set the score for this assembly task
         _order->SetAssemblyScore(assembly_score);
 
-        // Display the score in the terminal
+        // Display the score in the terminal only
         PrintAssemblyScore(_order, false, true);
     }
 
@@ -2643,7 +2643,7 @@ namespace ariac_plugins
         //----------------------------------------
         // Log outputs
         //----------------------------------------
-        if (_terminal_display){
+        if (_log_output){
             TrialLogOutput("-Order ID: ", assembly_score->GetOrderId() + "\n");
             TrialLogOutput("\t-Type: ", "Assembly\n");
              if (order_priority)
@@ -2692,7 +2692,7 @@ namespace ariac_plugins
             //----------------------------------------
             // Log outputs
             //----------------------------------------
-            if (_terminal_display){
+            if (_log_output){
                 TrialLogOutput("\t-Part: ", "[" + battery_type + "," + battery_color + "]\n");
                 TrialLogOutput("\t\t-Part score: ", std::to_string(battery->GetScore()) + "\n");
                 TrialLogOutput("\t\t-Correct type: ", "Yes\n");
@@ -2737,7 +2737,7 @@ namespace ariac_plugins
         //----------------------------------------
             // Log outputs
             //----------------------------------------
-            if (_terminal_display){
+            if (_log_output){
                 TrialLogOutput("\t-Part: ", "[" + pump_type + "," + pump_color + "]\n");
                 TrialLogOutput("\t\t-Part score: ", std::to_string(pump->GetScore()) + "\n");
                 TrialLogOutput("\t\t-Correct type: ", "Yes\n");
@@ -2784,7 +2784,7 @@ namespace ariac_plugins
             //----------------------------------------
             // Log outputs
             //----------------------------------------
-            if (_terminal_display){
+            if (_log_output){
                 TrialLogOutput("\t-Part: ", "[" + regulator_type + "," + regulator_color + "]\n");
                 TrialLogOutput("\t\t-Part score: ", std::to_string(regulator->GetScore()) + "\n");
                 TrialLogOutput("\t\t-Correct type: ", "Yes\n");
@@ -2829,7 +2829,7 @@ namespace ariac_plugins
             //----------------------------------------
             // Log outputs
             //----------------------------------------
-            if (_terminal_display){
+            if (_log_output){
                 TrialLogOutput("\t-Part: ", "[" + sensor_type + "," + sensor_color + "]\n");
                 TrialLogOutput("\t\t-Part score: ", std::to_string(sensor->GetScore()) + "\n");
                 TrialLogOutput("\t\t-Correct type: ", "Yes\n");
@@ -3347,9 +3347,9 @@ namespace ariac_plugins
         output += TerminalDisplay("Completion time: ", "green") + std::to_string(trial_completion_time) + "\n";
         output += TerminalDisplay("Max score: ", "green") + std::to_string(max_score) + "\n";
         output += TerminalDisplay("Actual score: ", "green") + std::to_string((int)trial_score_) + "\n";
-        output += TerminalDisplay("========================================\n", "yellow");
-        output += TerminalDisplay("Orders Summary\n", "yellow");
-        output += TerminalDisplay("========================================\n", "yellow");
+        // output += TerminalDisplay("========================================\n", "yellow");
+        // output += TerminalDisplay("Orders Summary\n", "yellow");
+        // output += TerminalDisplay("========================================\n", "yellow");
 
         // ----------------------------------------
         // Log the trial summary
@@ -3377,11 +3377,12 @@ namespace ariac_plugins
         {
             if (order->GetKittingScore())
             {
-                PrintKittingScore(order, true, true);
+                PrintKittingScore(order, true, false);
             }
             if (order->GetAssemblyScore())
             {
-                PrintAssemblyScore(order, true, true);
+                // Only log the result (no terminal display)
+                PrintAssemblyScore(order, true, false);
             }
             // if (order->GetCombinedScore())
             // {

--- a/ariac_plugins/src/task_manager_plugin.cpp
+++ b/ariac_plugins/src/task_manager_plugin.cpp
@@ -281,7 +281,8 @@ namespace ariac_plugins
         /*!< Print details of the score for an assembly task. */
         void PrintAssemblyScore(std::shared_ptr<ariac_common::Order> _order, bool _log_output=false, bool _terminal_display=false);
         /*!< Print details of the score for a combined task. */
-        void PrintCombinedScore(std::shared_ptr<ariac_common::CombinedScore> combined_score);
+        void PrintCombinedScore(std::shared_ptr<ariac_common::Order> _order, bool _log_output=false, bool _terminal_display=false);
+
         
 
         /*!< Print details of the score for the trial. */
@@ -794,8 +795,27 @@ namespace ariac_plugins
                 if (impl_->elapsed_time_ >= order->GetAnnouncementTime() && !order->IsAnnounced())
                 {
                     auto order_message = BuildOrderMsg(order);
+                    // std::string output="";
                     // RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(), "Announcing order");
                     impl_->DisplayTaskManagerInfo("Announcing order");
+                    
+                    // output += TerminalDisplay("========================================\n", "yellow");
+                    // output += TerminalDisplay("Announcing Order\n", "yellow");
+                    // output += TerminalDisplay("========================================\n", "yellow");
+                    // output += TerminalDisplay("Order ID: ", "green") + order->GetId() + "\n";
+
+                    // if (order->GetId() == 0)
+                    //     output += TerminalDisplay("Type: ", "green") +  "Kitting\n";
+                    // else if (order->GetId() == 1)
+                    //     output += TerminalDisplay("Type: ", "green") +  "Assembly\n";
+                    // else if (order->GetId() == 2)
+                    //     output += TerminalDisplay("Type: ", "green") +  "Combined\n";
+
+
+                    // //  + kitting_score->GetOrderId() + "\n"
+
+                    // auto order_id = order->GetId();
+
                     RCLCPP_INFO_STREAM(impl_->ros_node_->get_logger(), "\n" << *order);
 
                     impl_->order_pub_->publish(order_message);
@@ -2681,6 +2701,295 @@ namespace ariac_plugins
             else
                 output += TerminalDisplay("\t\t-Correct color? ", "green") + "No\n";
 
+            if (battery->GetIsFaulty())
+                output += TerminalDisplay("\t\t-Is faulty? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Is faulty? ", "green") + "No\n";
+
+            if (battery->GetCorrectPose())
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "No\n";
+
+            output += TerminalDisplay("\t\t\t-Position: ", "green") + std::to_string(battery->GetPosition().x) + ", " + std::to_string(battery->GetPosition().y) + ", " + std::to_string(battery->GetPosition().z) + "\n";
+            output += TerminalDisplay("\t\t\t-Orientation: ", "green") + std::to_string(battery->GetOrientation().x) + ", " + std::to_string(battery->GetOrientation().y) + ", " + std::to_string(battery->GetOrientation().z) + "\n";
+            
+            //----------------------------------------
+            // Log outputs
+            //----------------------------------------
+            if (_log_output){
+                TrialLogOutput("\t-Part: ", "[" + battery_type + "," + battery_color + "]\n");
+                TrialLogOutput("\t\t-Part score: ", std::to_string(battery->GetScore()) + "\n");
+                TrialLogOutput("\t\t-Correct type: ", "Yes\n");
+
+                if (battery->GetCorrectColor())
+                    TrialLogOutput("\t\t-Correct color? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct color? ", "No\n");
+
+                if (battery->GetIsFaulty())
+                    TrialLogOutput("\t\t-Is faulty? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Is faulty? ", "No\n");
+
+                if (battery->GetCorrectPose())
+                    TrialLogOutput("\t\t-Correct pose? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct pose? ", "No\n");
+
+                TrialLogOutput("\t\t\t-Position: ", std::to_string(battery->GetPosition().x) + ", " + std::to_string(battery->GetPosition().y) + ", " + std::to_string(battery->GetPosition().z) + "\n");
+                TrialLogOutput("\t\t\t-Orientation: ", std::to_string(battery->GetOrientation().x) + ", " + std::to_string(battery->GetOrientation().y) + ", " + std::to_string(battery->GetOrientation().z) + "\n");
+            }
+        }
+        if (pump != nullptr)
+        {
+            auto pump_type = ariac_common::ConvertPartTypeToString(pump->GetPart().GetType());
+            auto pump_color = ariac_common::ConvertPartColorToString(pump->GetPart().GetColor());
+            output += TerminalDisplay("\t-Part: ", "green") + "[" + pump_type + "," + pump_color + "]\n";
+            output += TerminalDisplay("\t\t-Part score: ", "green") + std::to_string(pump->GetScore()) + "\n";
+
+
+            output += TerminalDisplay("\t\t-Correct type: ", "green") + "Yes\n";
+
+            if (pump->GetCorrectColor())
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "No\n";
+
+            if (pump->GetIsFaulty())
+                TrialLogOutput("\t\t-Is faulty? ", "Yes\n");
+            else
+                TrialLogOutput("\t\t-Is faulty? ", "No\n");
+
+            if (pump->GetCorrectPose())
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "No\n";
+
+            output += TerminalDisplay("\t\t\t-Position: ", "green") + std::to_string(pump->GetPosition().x) + ", " + std::to_string(pump->GetPosition().y) + ", " + std::to_string(pump->GetPosition().z) + "\n";
+            output += TerminalDisplay("\t\t\t-Orientation: ", "green") + std::to_string(pump->GetOrientation().x) + ", " + std::to_string(pump->GetOrientation().y) + ", " + std::to_string(pump->GetOrientation().z) + "\n";
+        
+        //----------------------------------------
+            // Log outputs
+            //----------------------------------------
+            if (_log_output){
+                TrialLogOutput("\t-Part: ", "[" + pump_type + "," + pump_color + "]\n");
+                TrialLogOutput("\t\t-Part score: ", std::to_string(pump->GetScore()) + "\n");
+                TrialLogOutput("\t\t-Correct type: ", "Yes\n");
+
+                if (pump->GetCorrectColor())
+                    TrialLogOutput("\t\t-Correct color? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct color? ", "No\n");
+
+                if (pump->GetIsFaulty())
+                    TrialLogOutput("\t\t-Is faulty? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Is faulty? ", "No\n");
+
+                if (pump->GetCorrectPose())
+                    TrialLogOutput("\t\t-Correct pose? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct pose? ", "No\n");
+
+                TrialLogOutput("\t\t\t-Position: ", std::to_string(pump->GetPosition().x) + ", " + std::to_string(pump->GetPosition().y) + ", " + std::to_string(pump->GetPosition().z) + "\n");
+                TrialLogOutput("\t\t\t-Orientation: ", std::to_string(pump->GetOrientation().x) + ", " + std::to_string(pump->GetOrientation().y) + ", " + std::to_string(pump->GetOrientation().z) + "\n");
+            }
+        
+        
+        }
+        if (regulator != nullptr)
+        {
+            auto regulator_type = ariac_common::ConvertPartTypeToString(regulator->GetPart().GetType());
+            auto regulator_color = ariac_common::ConvertPartColorToString(regulator->GetPart().GetColor());
+            output += TerminalDisplay("\t-Part: ", "green") + "[" + regulator_type + "," + regulator_color + "]\n";
+            output += TerminalDisplay("\t\t-Part score: ", "green") + std::to_string(regulator->GetScore()) + "\n";
+
+
+            output += TerminalDisplay("\t\t-Correct type: ", "green") + "Yes\n";
+
+            if (regulator->GetCorrectColor())
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "No\n";
+
+            if (regulator->GetIsFaulty())
+                output += TerminalDisplay("\t\t-Is faulty? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Is faulty? ", "green") + "No\n";
+
+            if (regulator->GetCorrectPose())
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "No\n";
+
+            output += TerminalDisplay("\t\t\t-Position: ", "green") + std::to_string(regulator->GetPosition().x) + ", " + std::to_string(regulator->GetPosition().y) + ", " + std::to_string(regulator->GetPosition().z) + "\n";
+            output += TerminalDisplay("\t\t\t-Orientation: ", "green") + std::to_string(regulator->GetOrientation().x) + ", " + std::to_string(regulator->GetOrientation().y) + ", " + std::to_string(regulator->GetOrientation().z) + "\n";
+        
+            //----------------------------------------
+            // Log outputs
+            //----------------------------------------
+            if (_log_output){
+                TrialLogOutput("\t-Part: ", "[" + regulator_type + "," + regulator_color + "]\n");
+                TrialLogOutput("\t\t-Part score: ", std::to_string(regulator->GetScore()) + "\n");
+                TrialLogOutput("\t\t-Correct type: ", "Yes\n");
+
+                if (regulator->GetCorrectColor())
+                    TrialLogOutput("\t\t-Correct color? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct color? ", "No\n");
+
+                if (regulator->GetIsFaulty())
+                    TrialLogOutput("\t\t-Is faulty? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Is faulty? ", "No\n");
+
+                if (regulator->GetCorrectPose())
+                    TrialLogOutput("\t\t-Correct pose? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct pose? ", "No\n");
+
+                TrialLogOutput("\t\t\t-Position: ", std::to_string(regulator->GetPosition().x) + ", " + std::to_string(regulator->GetPosition().y) + ", " + std::to_string(regulator->GetPosition().z) + "\n");
+                TrialLogOutput("\t\t\t-Orientation: ", std::to_string(regulator->GetOrientation().x) + ", " + std::to_string(regulator->GetOrientation().y) + ", " + std::to_string(regulator->GetOrientation().z) + "\n");
+            }
+        }
+        if (sensor != nullptr)
+        {
+            auto sensor_type = ariac_common::ConvertPartTypeToString(sensor->GetPart().GetType());
+            auto sensor_color = ariac_common::ConvertPartColorToString(sensor->GetPart().GetColor());
+            output += TerminalDisplay("\t-Part: ", "green") + "[" + sensor_type + "," + sensor_color + "]\n";
+            output += TerminalDisplay("\t\t-Part score: ", "green") + std::to_string(sensor->GetScore()) + "\n";
+
+
+            output += TerminalDisplay("\t\t-Correct type: ", "green") + "Yes\n";
+
+            if (sensor->GetCorrectColor())
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "No\n";
+
+            if (sensor->GetIsFaulty())
+                output += TerminalDisplay("\t\t-Is faulty? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Is faulty? ", "green") + "No\n";
+
+            if (sensor->GetCorrectPose())
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct pose? ", "green") + "No\n";
+
+            output += TerminalDisplay("\t\t\t-Position: ", "green") + std::to_string(sensor->GetPosition().x) + ", " + std::to_string(sensor->GetPosition().y) + ", " + std::to_string(sensor->GetPosition().z) + "\n";
+            output += TerminalDisplay("\t\t\t-Orientation: ", "green") + std::to_string(sensor->GetOrientation().x) + ", " + std::to_string(sensor->GetOrientation().y) + ", " + std::to_string(sensor->GetOrientation().z) + "\n";
+       
+            //----------------------------------------
+            // Log outputs
+            //----------------------------------------
+            if (_log_output){
+                TrialLogOutput("\t-Part: ", "[" + sensor_type + "," + sensor_color + "]\n");
+                TrialLogOutput("\t\t-Part score: ", std::to_string(sensor->GetScore()) + "\n");
+                TrialLogOutput("\t\t-Correct type: ", "Yes\n");
+
+                if (sensor->GetCorrectColor())
+                    TrialLogOutput("\t\t-Correct color? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct color? ", "No\n");
+
+                if (sensor->GetIsFaulty())
+                    TrialLogOutput("\t\t-Is faulty? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Is faulty? ", "No\n");
+
+                if (sensor->GetCorrectPose())
+                    TrialLogOutput("\t\t-Correct pose? ", "Yes\n");
+                else
+                    TrialLogOutput("\t\t-Correct pose? ", "No\n");
+
+                TrialLogOutput("\t\t\t-Position: ", std::to_string(sensor->GetPosition().x) + ", " + std::to_string(sensor->GetPosition().y) + ", " + std::to_string(sensor->GetPosition().z) + "\n");
+                TrialLogOutput("\t\t\t-Orientation: ", std::to_string(sensor->GetOrientation().x) + ", " + std::to_string(sensor->GetOrientation().y) + ", " + std::to_string(sensor->GetOrientation().z) + "\n");
+            }
+        }
+
+        if (_terminal_display){
+            RCLCPP_INFO_STREAM(ros_node_->get_logger(), output);
+        }
+        // log_message_ += output;
+    }
+
+    //==============================================================================
+    void TaskManagerPluginPrivate::PrintCombinedScore(std::shared_ptr<ariac_common::Order> _order, bool _log_output, bool _terminal_display){
+
+        std::string output = "";
+
+        auto combined_score = _order->GetCombinedScore();
+        auto combined_task = _order->GetCombinedTask();
+        // order priority
+        auto order_priority = _order->IsPriority();
+        auto combined_completion_time = _order->GetSubmittedTime() - _order->GetAnnouncedTime();
+
+        output += TerminalDisplay("\n========================================\n", "yellow");
+        output += TerminalDisplay("Order Submitted\n", "yellow");
+        output += TerminalDisplay("========================================\n", "yellow");
+
+        output += TerminalDisplay("-Order ID: ", "green") + combined_score->GetOrderId() + "\n";
+        output += TerminalDisplay("\t-Type: ", "green") + "Combined\n";
+
+        if (order_priority)
+            output += TerminalDisplay("\t-Priority: ", "green") + "High\n";
+        else
+            output += TerminalDisplay("\t-Priority: ", "green") + "Regular\n";
+
+        output += TerminalDisplay("\t-Announcement time: ", "green") + std::to_string(_order->GetAnnouncedTime()) + "\n";
+        output += TerminalDisplay("\t-Submission time: ", "green") + std::to_string(_order->GetSubmittedTime()) + "\n";
+        output += TerminalDisplay("\t-Completion time: ", "green") + std::to_string(combined_completion_time) + "\n";
+        output += TerminalDisplay("\t-Station: ", "green") + std::to_string(combined_score->GetStation()) + "\n";
+        output += TerminalDisplay("\t-Bonus: ", "green") + std::to_string(combined_score->GetBonus()) + "\n";
+        output += TerminalDisplay("\t-Max score: ", "green") + std::to_string(ComputeMaxScoreCombinedTask(_order->GetCombinedTask()->GetProducts().size())) + "\n";
+        output += TerminalDisplay("\t-Actual score: ", "green") + std::to_string(combined_score->GetScore()) + "\n";
+        output += TerminalDisplay("\t-----------------------\n", "yellow");
+        output += TerminalDisplay("\tParts Summary\n", "yellow");
+        output += TerminalDisplay("\t-----------------------\n", "yellow"); 
+
+        //----------------------------------------
+        // Log outputs
+        //----------------------------------------
+        if (_log_output){
+            TrialLogOutput("-Order ID: ", combined_score->GetOrderId() + "\n");
+            TrialLogOutput("\t-Type: ", "Combined\n");
+             if (order_priority)
+                TrialLogOutput("\t-Priority: ", "High\n");
+            else
+                TrialLogOutput("\t-Priority: ", "Regular\n");
+
+            TrialLogOutput("\t-Announcement time: ", std::to_string(_order->GetAnnouncedTime()) + "\n");
+            TrialLogOutput("\t-Submission time: ", std::to_string(_order->GetSubmittedTime()) + "\n");
+            TrialLogOutput("\t-Completion time: ", std::to_string(combined_completion_time) + "\n");
+            TrialLogOutput("\t-Station: ", std::to_string(combined_score->GetStation()) + "\n");
+            TrialLogOutput("\t-Bonus: ", std::to_string(combined_score->GetBonus()) + "\n");
+            TrialLogOutput("\t-Max score: ", std::to_string(ComputeMaxScoreCombinedTask(_order->GetCombinedTask()->GetProducts().size())) + "\n");
+            TrialLogOutput("\t-Actual score: ", std::to_string(combined_score->GetScore()) + "\n");
+            TrialLogOutput("\t-----------------------\n");
+            TrialLogOutput("\tParts Summary\n");
+            TrialLogOutput("\t-----------------------\n");
+        }
+
+        auto battery = combined_score->GetBatteryPtr();
+        auto pump = combined_score->GetPumpPtr();
+        auto regulator = combined_score->GetRegulatorPtr();
+        auto sensor = combined_score->GetSensorPtr();
+
+        if (battery != nullptr)
+        {
+            auto battery_type = ariac_common::ConvertPartTypeToString(battery->GetPart().GetType());
+            auto battery_color = ariac_common::ConvertPartColorToString(battery->GetPart().GetColor());
+            output += TerminalDisplay("\t-Part: ", "green") + "[" + battery_type + "," + battery_color + "]\n";
+            output += TerminalDisplay("\t\t-Part score: ", "green") + std::to_string(battery->GetScore()) + "\n";
+            output += TerminalDisplay("\t\t-Correct type: ", "green") + "Yes\n";
+
+            if (battery->GetCorrectColor())
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "Yes\n";
+            else
+                output += TerminalDisplay("\t\t-Correct color? ", "green") + "No\n";
+
             if (battery->GetCorrectPose())
                 output += TerminalDisplay("\t\t-Correct pose? ", "green") + "Yes\n";
             else
@@ -2852,85 +3161,67 @@ namespace ariac_plugins
         if (_terminal_display){
             RCLCPP_INFO_STREAM(ros_node_->get_logger(), output);
         }
-        // log_message_ += output;
-    }
-
-    //==============================================================================
-    void TaskManagerPluginPrivate::PrintCombinedScore(std::shared_ptr<ariac_common::CombinedScore> combined_score)
-    {
-        std::string output = "";
-        output += "\n========================================\n";
-        output += "Order: " + combined_score->GetOrderId() + "\n";
-        output += "Type: Combined\n";
-        output += "Station: " + std::to_string(combined_score->GetStation()) + "\n";
-        output += "Bonus: " + std::to_string(combined_score->GetBonus()) + "\n";        
-        output += "Current Score: " + std::to_string(combined_score->GetScore()) + "\n";
-
-        auto battery = combined_score->GetBatteryPtr();
-        auto pump = combined_score->GetPumpPtr();
-        auto regulator = combined_score->GetRegulatorPtr();
-        auto sensor = combined_score->GetSensorPtr();
-        if (battery != nullptr)
-        {
-            auto battery_type = ariac_common::ConvertPartTypeToString(battery->GetPart().GetType());
-            auto battery_color = ariac_common::ConvertPartColorToString(battery->GetPart().GetColor());
-            output += "========================================\n";
-            output += "Part: [" + battery_type + "," + battery_color + "]\n";
-            output += "----------------------------------------\n";
-            output += "Type: Correct\n";
-            battery->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
-            battery->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
-            battery->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
-            output += "Position: " + std::to_string(battery->GetPosition().x) + ", " + std::to_string(battery->GetPosition().y) + ", " + std::to_string(battery->GetPosition().z) + "\n";
-            output += "Orientation: " + std::to_string(battery->GetOrientation().x) + ", " + std::to_string(battery->GetOrientation().y) + ", " + std::to_string(battery->GetOrientation().z) + "\n";
-            output += "Part score: " + std::to_string(battery->GetScore()) + "\n";
-        }
-        if (pump != nullptr)
-        {
-            auto pump_type = ariac_common::ConvertPartTypeToString(pump->GetPart().GetType());
-            auto pump_color = ariac_common::ConvertPartColorToString(pump->GetPart().GetColor());
-            output += "========================================\n";
-            output += "Part: [" + pump_type + "," + pump_color + "]\n";
-            output += "----------------------------------------\n";
-            output += "Type: Correct\n";
-            pump->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
-            pump->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
-            pump->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
-            output += "Position: " + std::to_string(pump->GetPosition().x) + ", " + std::to_string(pump->GetPosition().y) + ", " + std::to_string(pump->GetPosition().z) + "\n";
-            output += "Orientation: " + std::to_string(pump->GetOrientation().x) + ", " + std::to_string(pump->GetOrientation().y) + ", " + std::to_string(pump->GetOrientation().z) + "\n";
-            output += "Part score: " + std::to_string(pump->GetScore()) + "\n";
-        }
-        if (regulator != nullptr)
-        {
-            auto regulator_type = ariac_common::ConvertPartTypeToString(regulator->GetPart().GetType());
-            auto regulator_color = ariac_common::ConvertPartColorToString(regulator->GetPart().GetColor());
-            output += "========================================\n";
-            output += "Part: [" + regulator_type + "," + regulator_color + "]\n";
-            output += "----------------------------------------\n";
-            output += "Type: Correct\n";
-            regulator->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
-            regulator->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
-            regulator->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
-            output += "Position: " + std::to_string(regulator->GetPosition().x) + ", " + std::to_string(regulator->GetPosition().y) + ", " + std::to_string(regulator->GetPosition().z) + "\n";
-            output += "Orientation: " + std::to_string(regulator->GetOrientation().x) + ", " + std::to_string(regulator->GetOrientation().y) + ", " + std::to_string(regulator->GetOrientation().z) + "\n";
-            output += "Part score: " + std::to_string(regulator->GetScore()) + "\n";
-        }
-        if (sensor != nullptr)
-        {
-            auto sensor_type = ariac_common::ConvertPartTypeToString(sensor->GetPart().GetType());
-            auto sensor_color = ariac_common::ConvertPartColorToString(sensor->GetPart().GetColor());
-            output += "========================================\n";
-            output += "Part: [" + sensor_type + "," + sensor_color + "]\n";
-            output += "----------------------------------------\n";
-            output += "Type: Correct\n";
-            sensor->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
-            sensor->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
-            sensor->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
-            output += "Position: " + std::to_string(sensor->GetPosition().x) + ", " + std::to_string(sensor->GetPosition().y) + ", " + std::to_string(sensor->GetPosition().z) + "\n";
-            output += "Orientation: " + std::to_string(sensor->GetOrientation().x) + ", " + std::to_string(sensor->GetOrientation().y) + ", " + std::to_string(sensor->GetOrientation().z) + "\n";
-            output += "Part score: " + std::to_string(sensor->GetScore()) + "\n";
-            output += "----------------------------------------\n";
-        }
+        // if (battery != nullptr)
+        // {
+        //     auto battery_type = ariac_common::ConvertPartTypeToString(battery->GetPart().GetType());
+        //     auto battery_color = ariac_common::ConvertPartColorToString(battery->GetPart().GetColor());
+        //     output += "========================================\n";
+        //     output += "Part: [" + battery_type + "," + battery_color + "]\n";
+        //     output += "----------------------------------------\n";
+        //     output += "Type: Correct\n";
+        //     battery->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
+        //     battery->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
+        //     battery->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
+        //     output += "Position: " + std::to_string(battery->GetPosition().x) + ", " + std::to_string(battery->GetPosition().y) + ", " + std::to_string(battery->GetPosition().z) + "\n";
+        //     output += "Orientation: " + std::to_string(battery->GetOrientation().x) + ", " + std::to_string(battery->GetOrientation().y) + ", " + std::to_string(battery->GetOrientation().z) + "\n";
+        //     output += "Part score: " + std::to_string(battery->GetScore()) + "\n";
+        // }
+        // if (pump != nullptr)
+        // {
+        //     auto pump_type = ariac_common::ConvertPartTypeToString(pump->GetPart().GetType());
+        //     auto pump_color = ariac_common::ConvertPartColorToString(pump->GetPart().GetColor());
+        //     output += "========================================\n";
+        //     output += "Part: [" + pump_type + "," + pump_color + "]\n";
+        //     output += "----------------------------------------\n";
+        //     output += "Type: Correct\n";
+        //     pump->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
+        //     pump->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
+        //     pump->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
+        //     output += "Position: " + std::to_string(pump->GetPosition().x) + ", " + std::to_string(pump->GetPosition().y) + ", " + std::to_string(pump->GetPosition().z) + "\n";
+        //     output += "Orientation: " + std::to_string(pump->GetOrientation().x) + ", " + std::to_string(pump->GetOrientation().y) + ", " + std::to_string(pump->GetOrientation().z) + "\n";
+        //     output += "Part score: " + std::to_string(pump->GetScore()) + "\n";
+        // }
+        // if (regulator != nullptr)
+        // {
+        //     auto regulator_type = ariac_common::ConvertPartTypeToString(regulator->GetPart().GetType());
+        //     auto regulator_color = ariac_common::ConvertPartColorToString(regulator->GetPart().GetColor());
+        //     output += "========================================\n";
+        //     output += "Part: [" + regulator_type + "," + regulator_color + "]\n";
+        //     output += "----------------------------------------\n";
+        //     output += "Type: Correct\n";
+        //     regulator->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
+        //     regulator->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
+        //     regulator->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
+        //     output += "Position: " + std::to_string(regulator->GetPosition().x) + ", " + std::to_string(regulator->GetPosition().y) + ", " + std::to_string(regulator->GetPosition().z) + "\n";
+        //     output += "Orientation: " + std::to_string(regulator->GetOrientation().x) + ", " + std::to_string(regulator->GetOrientation().y) + ", " + std::to_string(regulator->GetOrientation().z) + "\n";
+        //     output += "Part score: " + std::to_string(regulator->GetScore()) + "\n";
+        // }
+        // if (sensor != nullptr)
+        // {
+        //     auto sensor_type = ariac_common::ConvertPartTypeToString(sensor->GetPart().GetType());
+        //     auto sensor_color = ariac_common::ConvertPartColorToString(sensor->GetPart().GetColor());
+        //     output += "========================================\n";
+        //     output += "Part: [" + sensor_type + "," + sensor_color + "]\n";
+        //     output += "----------------------------------------\n";
+        //     output += "Type: Correct\n";
+        //     sensor->GetCorrectColor() ? output += "Color: Correct\n" : output += "Color: Incorrect\n";
+        //     sensor->GetCorrectPose() ? output += "Pose: Correct\n" : output += "Pose: Incorrect\n";
+        //     sensor->GetIsFaulty() ? output += "Faulty: Yes\n" : output += "Faulty: No\n";
+        //     output += "Position: " + std::to_string(sensor->GetPosition().x) + ", " + std::to_string(sensor->GetPosition().y) + ", " + std::to_string(sensor->GetPosition().z) + "\n";
+        //     output += "Orientation: " + std::to_string(sensor->GetOrientation().x) + ", " + std::to_string(sensor->GetOrientation().y) + ", " + std::to_string(sensor->GetOrientation().z) + "\n";
+        //     output += "Part score: " + std::to_string(sensor->GetScore()) + "\n";
+        //     output += "----------------------------------------\n";
+        // }
 
         // RCLCPP_INFO_STREAM(ros_node_->get_logger(), output);
         // log_message_ += output;
@@ -3130,7 +3421,7 @@ namespace ariac_plugins
         _order->SetCombinedScore(combined_score);
 
         // Display the score in the terminal
-        PrintCombinedScore(combined_score);
+        PrintCombinedScore(_order);
     }
 
     // ==================================== //
@@ -3384,14 +3675,11 @@ namespace ariac_plugins
                 // Only log the result (no terminal display)
                 PrintAssemblyScore(order, true, false);
             }
-            // if (order->GetCombinedScore())
-            // {
-            //     combined_order = order;
-            //     combined_score = order->GetCombinedScore();
-            //     combined_submitted_time = combined_order->GetSubmittedTime();
-            //     combined_completion_time = combined_submitted_time - combined_order->GetAnnouncedTime();
-            //     completion_times.push_back(combined_completion_time);
-            // }
+            if (order->GetCombinedScore())
+            {
+                // Only log the result (no terminal display)
+                PrintCombinedScore(order, true, false);
+            }
         }
         RCLCPP_INFO_STREAM(ros_node_->get_logger(), output);
         // log_message_ += output;


### PR DESCRIPTION
Changes made to results displayed in the terminal and in the generated log file (trial_log.txt).

The test competitor does not properly handle combined tasks (kitting is fine but assembly fails). Although the log files can theoretically display results for combined tasks, I couldn't really test it due to the issue with the test competitor.

Below is an example of content for a trial with 2 kitting orders and 1 assembly order.


```
========================================
Trial Summary
========================================
Trial file: custom.yaml
Trial time limit: No time limit
Completion time: 339.334000
Max score: 50.000000
Actual score: 33
========================================
Orders Summary
========================================
-Order ID: MMB30H56
	-Type: Kitting
	-Announcement time: 0.000000
	-Submission time: 132.527000
	-Completion time: 132.527000
	-AGV: 3
	-Tray score: 3
	-Correct destination? Yes
	-Bonus: 2
	-Max score: 11
	-Actual score: 11
	-----------------------
	Quadrants Summary
	-----------------------
	-Quadrant: 3
		-Score: 3
		-Correct part type? Yes
		-Correct part color? Yes
		-Faulty part? No
		-Flipped part? No
	-Quadrant: 4
		-Score: 3
		-Correct part type? Yes
		-Correct part color? Yes
		-Faulty part? No
		-Flipped part? No
-Order ID: MMB30H57
	-Type: Kitting
	-Announcement time: 20.000000
	-Submission time: 243.532000
	-Completion time: 223.532000
	-AGV: 4
	-Tray score: 3
	-Correct destination? Yes
	-Bonus: 2
	-Max score: 11
	-Actual score: 11
	-----------------------
	Quadrants Summary
	-----------------------
	-Quadrant: 1
		-Score: 3
		-Correct part type? Yes
		-Correct part color? Yes
		-Faulty part? No
		-Flipped part? No
	-Quadrant: 3
		-Score: 3
		-Correct part type? Yes
		-Correct part color? Yes
		-Faulty part? No
		-Flipped part? No
-Order ID: 2IZJP127
	-Type: Assembly
	-Priority: Regular
	-Announcement time: 30.000000
	-Submission time: 369.334000
	-Completion time: 339.334000
	-Station: 1
	-Bonus: 0
	-Max score: 28
	-Actual score: 11
	-----------------------
	Parts Summary
	-----------------------
	-Part: [battery,red]
		-Part score: 2
		-Correct type: Yes
		-Correct color? Yes
		-Correct pose? No
			-Position: -0.145950, -0.013118, 0.044697
			-Orientation: -0.111871, -0.138469, 1.652635
	-Part: [pump,red]
		-Part score: 3
		-Correct type: Yes
		-Correct color? Yes
		-Correct pose? Yes
			-Position: 0.139818, 0.000344, 0.021018
			-Orientation: 0.000125, -0.000360, -1.571287
	-Part: [regulator,red]
		-Part score: 3
		-Correct type: Yes
		-Correct color? Yes
		-Correct pose? Yes
			-Position: 0.175195, -0.222801, 0.215984
			-Orientation: 1.568932, -0.003285, -1.571244
	-Part: [sensor,red]
		-Part score: 3
		-Correct type: Yes
		-Correct color? Yes
		-Correct pose? Yes
			-Position: -0.106773, 0.388839, 0.028721
			-Orientation: -0.062836, -0.333601, -1.506668

```
