### PR TITLE
Fix gripper_joint issue #314

### DIFF
--- a/ariac_description/urdf/vacuum_gripper/vacuum_gripper_macro.xacro
+++ b/ariac_description/urdf/vacuum_gripper/vacuum_gripper_macro.xacro
@@ -32,13 +32,15 @@
     </link>
 
     <!-- Gripper Joint -->
-    <joint name="${prefix}_gripper_joint" type="revolute">
-      <axis xyz="0 0 1"/>
+    <joint name="${prefix}_gripper_joint" type="fixed">
       <parent link="${prefix}_${parent}"/>
       <child link="${prefix}_gripper"/>
-      <limit lower="-.001" upper=".001" effort="1000" velocity="0" />
       <origin xyz="0.0 0.0 0.01" rpy="0.0 0.0 0.0"/>
     </joint>
+
+    <gazebo reference='${prefix}_gripper_joint'>
+      <preserveFixedJoint>true</preserveFixedJoint>
+    </gazebo>
 
     <!-- Add a contact sensor to the gripper -->
     <gazebo reference="${prefix}_gripper">

--- a/ariac_moveit_config/config/ariac_robots.srdf
+++ b/ariac_moveit_config/config/ariac_robots.srdf
@@ -26,8 +26,7 @@
     </group>
     <!--GROUP STATES: Purpose: Define a named state for a particular group, in terms of joint values. This is useful to define states like 'folded arms'-->
     <group_state name="home" group="floor_robot">
-        <joint name="floor_elbow_joint" value="1.571"/>
-        <joint name="floor_gripper_joint" value="0"/>
+        <joint name="floor_elbow_joint" value="1.571"/>>
         <joint name="floor_shoulder_lift_joint" value="-1.571"/>
         <joint name="floor_shoulder_pan_joint" value="0"/>
         <joint name="floor_wrist_1_joint" value="-1.571"/>
@@ -37,7 +36,6 @@
     </group_state>
     <group_state name="home" group="ceiling_robot">
         <joint name="ceiling_elbow_joint" value="1.571"/>
-        <joint name="ceiling_gripper_joint" value="0"/>
         <joint name="ceiling_shoulder_lift_joint" value="-1.571"/>
         <joint name="ceiling_shoulder_pan_joint" value="0"/>
         <joint name="ceiling_wrist_1_joint" value="3.14"/>
@@ -47,9 +45,6 @@
         <joint name="gantry_y_axis_joint" value="0"/>
         <joint name="gantry_rotation_joint" value="-1.571"/>
     </group_state>
-    <!--PASSIVE JOINT: Purpose: this element is used to mark joints that are not actuated-->
-    <passive_joint name="floor_gripper_joint"/>
-    <passive_joint name="ceiling_gripper_joint"/>
     
     <!--DISABLE COLLISIONS: By default it is assumed that any link of the robot could potentially come into collision with any other link in the robot. This tag disables collision checking between a specified pair of links. -->
     <disable_collisions link1="agv1_base" link2="agv1_tray" reason="Adjacent"/>

--- a/ariac_moveit_config/config/joint_limits.yaml
+++ b/ariac_moveit_config/config/joint_limits.yaml
@@ -20,11 +20,6 @@ joint_limits:
   floor_wrist_3_joint:
     has_acceleration_limits: true
     max_acceleration: 5.0
-  floor_gripper_joint:
-    has_velocity_limits: true
-    max_velocity: 1.0
-    has_acceleration_limits: true
-    max_acceleration: 0.5
   gantry_x_axis_joint:
     has_acceleration_limits: true
     max_acceleration: 0.5
@@ -52,8 +47,3 @@ joint_limits:
   ceiling_wrist_3_joint:
     has_acceleration_limits: true
     max_acceleration: 5.0
-  ceiling_gripper_joint:
-    has_velocity_limits: true
-    max_velocity: 1.0
-    has_acceleration_limits: true
-    max_acceleration: 0.5


### PR DESCRIPTION
Fixes issue #314 by replacing revolute joint with fixed joint. This is possible due to additional urdf tag: 

`<preserveFixedJoint>true</preserveFixedJoint>`

that was mentioned [here](https://github.com/gazebosim/gazebo-classic/issues/2732).