### PR TITLE
fix qos of trial_config subscriber to implement droppedpart challenge

### DIFF
--- a/ariac_plugins/src/vacuum_gripper_plugin.cpp
+++ b/ariac_plugins/src/vacuum_gripper_plugin.cpp
@@ -155,11 +155,10 @@ namespace ariac_plugins
     impl_->first_publish_ = true;
 
     // Connect Subscribers
-    rclcpp::QoS custom_qos(1);
-    custom_qos.transient_local();
+    rclcpp::QoS qos_profile = rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable();  
 
-    impl_->trial_config_sub_ = impl_->ros_node_->create_subscription<ariac_msgs::msg::Trial>(
-        "/ariac/trial_config", custom_qos,
+    impl_->trial_config_sub_ = impl_->ros_node_->create_subscription<ariac_msgs::msg::Trial>(  
+        "/ariac/trial_config", qos.get_subscription_qos("/ariac/trial_config", qos_profile),  
         std::bind(&VacuumGripperPluginPrivate::OnTrialCallback, impl_.get(), std::placeholders::_1));
 
     // Register enable service

--- a/ariac_plugins/src/vacuum_gripper_plugin.cpp
+++ b/ariac_plugins/src/vacuum_gripper_plugin.cpp
@@ -155,8 +155,11 @@ namespace ariac_plugins
     impl_->first_publish_ = true;
 
     // Connect Subscribers
+    rclcpp::QoS custom_qos(1);
+    custom_qos.transient_local();
+
     impl_->trial_config_sub_ = impl_->ros_node_->create_subscription<ariac_msgs::msg::Trial>(
-        "/ariac/trial_config", qos.get_subscription_qos("/ariac/trial_config", rclcpp::QoS(1)),
+        "/ariac/trial_config", custom_qos,
         std::bind(&VacuumGripperPluginPrivate::OnTrialCallback, impl_.get(), std::placeholders::_1));
 
     // Register enable service


### PR DESCRIPTION
The Dropped part Challenge does not work because of the Qos profile mismatch between the publisher and subscriber.