### PR TITLE
Add optical frames for all rgb and rgbd cameras

### DIFF
--- a/ariac_description/urdf/vacuum_gripper/vacuum_gripper_macro.xacro
+++ b/ariac_description/urdf/vacuum_gripper/vacuum_gripper_macro.xacro
@@ -107,6 +107,9 @@
         </visual>
       </link>
 
+      <link name ="${prefix}_robot_camera_optical_link">
+      </link>
+
       <!-- Add camera mount joint -->
       <joint name="${prefix}_robot_camera_mount_joint" type="fixed">
         <axis xyz="0 1 0" />
@@ -121,6 +124,14 @@
         <origin xyz="0 -.07 -.006" rpy="0 -1.57 1.57"/>
         <parent link="${prefix}_robot_camera_mount_link"/>
         <child link="${prefix}_robot_camera_link"/>
+      </joint>
+
+      <!-- Add optical joint -->
+      <joint name="${prefix}_robot_camera_optical_joint" type="fixed">
+        <axis xyz="0 1 0" />
+        <origin xyz="0 0 0" rpy="-1.57 0 -1.57"/>
+        <parent link="${prefix}_robot_camera_link"/>
+        <child link="${prefix}_robot_camera_optical_link"/>
       </joint>
 
       <!-- Add color to links -->

--- a/ariac_gazebo/nodes/sensor_tf_broadcaster.py
+++ b/ariac_gazebo/nodes/sensor_tf_broadcaster.py
@@ -40,6 +40,20 @@ def main():
 
         sensor_tf_broadcaster.generate_transform('world', sensor_name + "_frame", pose)
 
+        # Publish optical frame for cameras
+        try:
+            if 'rgb' in sensors[sensor_name]['type']:
+                xyz = [0, 0, 0]
+                rpy = ['-pi/2', 0, '-pi/2']
+                
+                optical_pose = pose_info(xyz, rpy)
+
+                sensor_tf_broadcaster.generate_transform(
+                    sensor_name + "_frame", sensor_name + "_optical_frame", optical_pose)
+
+        except KeyError:
+            pass
+
     # Send tf transforms
     sensor_tf_broadcaster.send_transforms()
 


### PR DESCRIPTION
Adds an additional TF frame for all RGB and RGBD cameras (static and robot) where the z-axis is aligned with the direction of the camera FOV. 

The transform between the base sensor frame and the optical frame is:
- roll: -pi/2
- pitch: 0.0
- yaw: -pi/2  